### PR TITLE
Update socks.py to work with Python 3.12

### DIFF
--- a/lib/third_party/socks.py
+++ b/lib/third_party/socks.py
@@ -59,7 +59,7 @@ import struct
 from errno import EOPNOTSUPP, EINVAL, EAGAIN
 from io import BytesIO
 from os import SEEK_CUR
-from collections import Callable
+from collections.abc import Callable
 from base64 import b64encode
 
 PROXY_TYPE_SOCKS4 = SOCKS4 = 1


### PR DESCRIPTION
The Internet tells me that this line needs to change to `from collections.abc import Callable`.  I don't speak Python, but this change allowed it to run on Ubuntu 24.10.

I'm not a Python developer.  This is the bare minimum to make it appear to work with modern versions of Python.  I'm sure there's other code cleanup needed.